### PR TITLE
jobs: enroll coreos/ignition-dracut

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -1,6 +1,7 @@
 /* this job defines all the multibranch jobs for upstream CI repos */
 
 repos = [
+    "coreos/ignition-dracut"
     // "coreos/coreos-assembler",
     // "coreos/fedora-coreos-config",
     // "coreos/fedora-coreos-pipeline",


### PR DESCRIPTION
Before trying to migrate repos already hooked up to projectatomic-ci,
let's start with a repo which doesn't currently have any PR testing set
up to make sure everything works.

Requires: https://github.com/jlebon/coreos-ci/pull/1