### PR TITLE
coreos-ci-lib: default to coreos-ci branch

### DIFF
--- a/jenkins/config/coreos-ci-lib.yaml
+++ b/jenkins/config/coreos-ci-lib.yaml
@@ -2,7 +2,7 @@ unclassified:
   globalLibraries:
     libraries:
       - name: coreos
-        defaultVersion: master
+        defaultVersion: coreos-ci
         implicit: true
         retriever:
           modernSCM:


### PR DESCRIPTION
As mentioned here:

https://github.com/coreos/coreos-ci-lib/pull/10#issuecomment-586016504

we're currently using the `coreos-ci` branch for the new repos hooked up
to CoreOS CI so as to not have breaking changes to master affect
previously hooked up repos.