### PR TITLE
jobs: migrate coreos/coreos-assembler

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -2,7 +2,7 @@
 
 repos = [
     "coreos/ignition-dracut"
-    // "coreos/coreos-assembler",
+    "coreos/coreos-assembler",
     // "coreos/fedora-coreos-config",
     // "coreos/fedora-coreos-pipeline",
     // "coreos/fedora-coreos-streams",


### PR DESCRIPTION
Let's migrate repos over to the new project, starting with the most
popular one.