### PR TITLE
jobs: migrate coreos/fedora-coreos-*

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -2,10 +2,10 @@
 
 repos = [
     "coreos/ignition-dracut",
-    "coreos/coreos-assembler"
-    // "coreos/fedora-coreos-config",
-    // "coreos/fedora-coreos-pipeline",
-    // "coreos/fedora-coreos-streams",
+    "coreos/coreos-assembler",
+    "coreos/fedora-coreos-config",
+    "coreos/fedora-coreos-pipeline",
+    "coreos/fedora-coreos-streams"
     // "coreos/ignition",
     // "coreos/mantle",
     // "coreos/rpm-ostree",


### PR DESCRIPTION
These ones should be be pretty easy to migrate.

Works on top of https://github.com/coreos/coreos-ci/pull/5.