### PR TITLE
jobs: migrate ostreedev/ostree

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -7,8 +7,8 @@ repos = [
     "coreos/fedora-coreos-streams",
     "coreos/ignition",
     "coreos/ignition-dracut",
-    "coreos/rpm-ostree"
-    //"ostreedev/ostree
+    "coreos/rpm-ostree",
+    "ostreedev/ostree
 ]
 
 node { repos.each { repo ->


### PR DESCRIPTION
Final one to migrate!

Then we can start enrolling other repos that still need some CI.