### PR TITLE
config: use master branch of coreos-ci-lib

### DIFF
--- a/jenkins/config/coreos-ci-lib.yaml
+++ b/jenkins/config/coreos-ci-lib.yaml
@@ -2,7 +2,7 @@ unclassified:
   globalLibraries:
     libraries:
       - name: coreos
-        defaultVersion: coreos-ci
+        defaultVersion: master
         implicit: true
         retriever:
           modernSCM:


### PR DESCRIPTION
We can go back to using master on this now.