### PR TITLE
config: drop repo scope from oauth config

### DIFF
--- a/jenkins/config/github-oauth.yaml
+++ b/jenkins/config/github-oauth.yaml
@@ -5,7 +5,7 @@ jenkins:
       githubApiUri: https://api.github.com
       clientID: ${github-oauth/client-id}
       clientSecret: ${github-oauth/client-secret}
-      oauthScopes: read:org,user:email,repo
+      oauthScopes: read:org,user:email
   authorizationStrategy:
     globalMatrix:
       permissions:


### PR DESCRIPTION
I don't quite remember why I had added `repo` there... I don't think we
need this, so let's just drop it and see if something breaks.

Fixes: #12