### PR TITLE
config: don't implicitly load coreos-ci-lib

### DIFF
--- a/README-upstream-ci.md
+++ b/README-upstream-ci.md
@@ -21,7 +21,7 @@ Upstream repos must have a Jenkins pipeline in a file called
 This pipeline should heavily leverage the custom steps in
 [coreos-ci-lib](https://github.com/coreos/coreos-ci-lib).
 This is a global shared library which all jobs automatically
-have access to.
+have access to by using `@Library('coreos') _`.
 
 For example, here is a sample Jenkinsfile to build the
 software locally, build FCOS with its results overlayed and
@@ -29,6 +29,7 @@ run kola:
 
 ```groovy
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
+@Library('coreos') _
 
 cosaPod {
     checkout scm
@@ -45,3 +46,17 @@ In practice, it's likely that the `make: true` functionality
 in `coreos-ci-lib` will be too simplistic. The `fcosBuild`
 step can also take an arbitrary `overlays` parameter to pass
 any rootfs directory to overlay.
+
+### Testing patches to coreos-ci-lib
+
+It's likely that you will encounter situations where you
+want to test changes to coreos-ci-lib that work in tandem
+with your PR. To do this, you can point your Jenkinsfile at
+your branch:
+
+```
+@Library('github.com/jlebon/coreos-ci-lib@my-changes') _
+```
+
+Once the coreos-ci-lib patches are proposed and merged, you
+can point your PR back to the canonical repo.

--- a/jenkins/config/coreos-ci-lib.yaml
+++ b/jenkins/config/coreos-ci-lib.yaml
@@ -3,7 +3,7 @@ unclassified:
     libraries:
       - name: coreos
         defaultVersion: master
-        implicit: true
+        implicit: false
         retriever:
           modernSCM:
             scm:


### PR DESCRIPTION
Having it loaded implicitly is neat, though it has a major issue:
currently, Jenkins provides no way to avoid loading it, or overriding it
with a different git repo. This is a very important use case, because we
need to be able to test modifications to the library before merging. See
for example here where we want to hook up CI to coreos-ci-lib itself:

https://github.com/coreos/coreos-ci-lib/pull/15

(And correspondingly, on other repos which want to test their CI
combined with pending coreos-ci-lib changes).

Making it not implicitly loaded means that pipelines will now have to do
`@Library('coreos')` which isn't the end of the world.