### PR TITLE
Updates for OCP4 migration

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -1,8 +1,8 @@
-# This is a fork of the `jenkins-ephemeral` OpenShift template because we need
+# This is a fork of the `jenkins-persistent` OpenShift template because we need
 # to be able to pass in more information to the Jenkins pod, such as env vars,
 # secrets, configmaps, etc...
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   app: coreos-ci
@@ -10,19 +10,27 @@ labels:
 metadata:
   annotations:
     description: |-
-      Jenkins service for CoreOS CI.
+      Jenkins service, with persistent storage.
+
+      NOTE: You must have persistent volumes available in your cluster to use this template.
     iconClass: icon-jenkins
-    openshift.io/display-name: CoreOS CI Jenkins
-    openshift.io/documentation-url: https://github.com/coreos/coreos-ci
-    openshift.io/support-url: https://github.com/coreos/coreos-ci
-    openshift.io/provider-display-name: CoreOS CI
+    openshift.io/display-name: Jenkins
+    openshift.io/documentation-url: https://docs.okd.io/latest/using_images/other_images/jenkins.html
+    openshift.io/long-description: This template deploys a Jenkins server capable
+      of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/support-url: https://access.redhat.com
+    samples.operator.openshift.io/version: 4.4.10
     tags: fcos,jenkins,coreos,ci
+  labels:
+    samples.operator.openshift.io/managed: "true"
   name: coreos-ci-jenkins
 objects:
 - apiVersion: v1
   kind: Route
   metadata:
     annotations:
+      haproxy.router.openshift.io/timeout: 4m
       template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
     name: ${JENKINS_SERVICE_NAME}
   spec:
@@ -32,6 +40,16 @@ objects:
     to:
       kind: Service
       name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -56,33 +74,40 @@ objects:
             value: ${ENABLE_OAUTH}
           - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
             value: "true"
-          - name: OPENSHIFT_JENKINS_JVM_ARCH
-            value: ${JVM_ARCH}
+          - name: DISABLE_ADMINISTRATIVE_MONITORS
+            value: ${DISABLE_ADMINISTRATIVE_MONITORS}
           - name: KUBERNETES_MASTER
             value: https://kubernetes.default:443
           - name: KUBERNETES_TRUST_CERTIFICATES
             value: "true"
+          - name: JENKINS_SERVICE_NAME
+            value: ${JENKINS_SERVICE_NAME}
           - name: JNLP_SERVICE_NAME
             value: ${JNLP_SERVICE_NAME}
+          - name: ENABLE_FATAL_ERROR_LOG_FILE
+            value: ${ENABLE_FATAL_ERROR_LOG_FILE}
+          - name: JENKINS_UC_INSECURE
+            value: ${JENKINS_UC_INSECURE}
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 30
+            failureThreshold: 2
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 420
-            timeoutSeconds: 3
+            periodSeconds: 360
+            timeoutSeconds: 240
           name: jenkins
           readinessProbe:
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 3
-            timeoutSeconds: 3
+            timeoutSeconds: 240
           resources:
             limits:
               memory: ${MEMORY_LIMIT}
@@ -113,9 +138,9 @@ objects:
         restartPolicy: Always
         serviceAccountName: ${JENKINS_SERVICE_NAME}
         volumes:
-        - emptyDir:
-            medium: ""
-          name: ${JENKINS_SERVICE_NAME}-data
+        - name: ${JENKINS_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${JENKINS_SERVICE_NAME}
         # DELTA: add a configmap -- see config/jcasc.yaml
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:
@@ -209,23 +234,40 @@ parameters:
   name: ENABLE_OAUTH
   # DELTA: changed from true; we're using GitHub OAuth
   value: "false"
-- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
-  displayName: Jenkins JVM Architecture
-  name: JVM_ARCH
-  value: i386
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
-  # DELTA: changed from 512Mi
   name: MEMORY_LIMIT
-  value: 2Gi
+  # DELTA: changed from 1Gi
+  value: 4Gi
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  # DELTA: changed from 1Gi
+  value: 10Gi
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
   # DELTA: changed from openshift
   value: coreos-ci
+- description: Whether to perform memory intensive, possibly slow, synchronization
+    with the Jenkins Update Center on start.  If true, the Jenkins core update monitor
+    and site warnings monitor are disabled.
+  displayName: Disable memory intensive administrative monitors
+  name: DISABLE_ADMINISTRATIVE_MONITORS
+  value: "false"
 - description: Name of the ImageStreamTag to be used for the Jenkins image.
   displayName: Jenkins ImageStreamTag
   name: JENKINS_IMAGE_STREAM_TAG
-  # DELTA: changed from jenkins:latest
-  # https://github.com/coreos/fedora-coreos-pipeline/pull/70
   value: jenkins:2
+- description: When a fatal error occurs, an error log is created with information
+    and the state obtained at the time of the fatal error.
+  displayName: Fatal Error Log File
+  name: ENABLE_FATAL_ERROR_LOG_FILE
+  value: "false"
+- description: Whether to allow use of a Jenkins Update Center that uses invalid certificate
+    (self-signed, unknown CA). If any value other than 'false', certificate check
+    is bypassed. By default, certificate check is enforced.
+  displayName: Allows use of Jenkins Update Center repository with invalid SSL certificate
+  name: JENKINS_UC_INSECURE
+  value: "false"

--- a/manifests/jenkins.yaml.orig
+++ b/manifests/jenkins.yaml.orig
@@ -2,45 +2,44 @@
 # for rebasing.
 #
 # Obtained using:
-#   oc get templates -n openshift -o yaml jenkins-ephemeral > manifests/jenkins.yaml.orig
+#   oc get templates jenkins-persistent -n openshift -o yaml > manifests/jenkins.yaml.orig
 #
 # To diff:
 #   git diff --no-index manifests/jenkins.yaml{.orig,}
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
-  template: jenkins-ephemeral-template
+  app: jenkins-persistent
+  template: jenkins-persistent-template
 message: A Jenkins service has been created in your project.  Log into Jenkins with
   your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
   contains more information about using this template.
 metadata:
   annotations:
     description: |-
-      Jenkins service, without persistent storage.
+      Jenkins service, with persistent storage.
 
-      WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.
+      NOTE: You must have persistent volumes available in your cluster to use this template.
     iconClass: icon-jenkins
-    openshift.io/display-name: Jenkins (Ephemeral)
+    openshift.io/display-name: Jenkins
+    openshift.io/documentation-url: https://docs.okd.io/latest/using_images/other_images/jenkins.html
+    openshift.io/long-description: This template deploys a Jenkins server capable
+      of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/support-url: https://access.redhat.com
+    samples.operator.openshift.io/version: 4.4.10
     tags: instant-app,jenkins
-    template.openshift.io/documentation-url: https://docs.openshift.org/latest/using_images/other_images/jenkins.html
-    template.openshift.io/long-description: This template deploys a Jenkins server
-      capable of managing OpenShift Pipeline builds and supporting OpenShift-based
-      oauth login.  The Jenkins configuration is stored in non-persistent storage,
-      so this configuration should be used for experimental purposes only.
-    template.openshift.io/provider-display-name: Red Hat, Inc.
-    template.openshift.io/support-url: https://access.redhat.com
-  creationTimestamp: 2017-06-07T22:44:34Z
-  name: jenkins-ephemeral
+  labels:
+    samples.operator.openshift.io/managed: "true"
+  name: jenkins-persistent
   namespace: openshift
-  resourceVersion: "9280677"
-  selfLink: /oapi/v1/namespaces/openshift/templates/jenkins-ephemeral
-  uid: e101774f-4bd2-11e7-aab3-0cc47a66a374
 objects:
 - apiVersion: v1
   kind: Route
   metadata:
     annotations:
+      haproxy.router.openshift.io/timeout: 4m
       template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
     name: ${JENKINS_SERVICE_NAME}
   spec:
@@ -50,6 +49,16 @@ objects:
     to:
       kind: Service
       name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -74,30 +83,37 @@ objects:
             value: ${ENABLE_OAUTH}
           - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
             value: "true"
-          - name: OPENSHIFT_JENKINS_JVM_ARCH
-            value: ${JVM_ARCH}
+          - name: DISABLE_ADMINISTRATIVE_MONITORS
+            value: ${DISABLE_ADMINISTRATIVE_MONITORS}
           - name: KUBERNETES_MASTER
             value: https://kubernetes.default:443
           - name: KUBERNETES_TRUST_CERTIFICATES
             value: "true"
+          - name: JENKINS_SERVICE_NAME
+            value: ${JENKINS_SERVICE_NAME}
           - name: JNLP_SERVICE_NAME
             value: ${JNLP_SERVICE_NAME}
+          - name: ENABLE_FATAL_ERROR_LOG_FILE
+            value: ${ENABLE_FATAL_ERROR_LOG_FILE}
+          - name: JENKINS_UC_INSECURE
+            value: ${JENKINS_UC_INSECURE}
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 30
+            failureThreshold: 2
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 420
-            timeoutSeconds: 3
+            periodSeconds: 360
+            timeoutSeconds: 240
           name: jenkins
           readinessProbe:
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 3
-            timeoutSeconds: 3
+            timeoutSeconds: 240
           resources:
             limits:
               memory: ${MEMORY_LIMIT}
@@ -112,9 +128,9 @@ objects:
         restartPolicy: Always
         serviceAccountName: ${JENKINS_SERVICE_NAME}
         volumes:
-        - emptyDir:
-            medium: ""
-          name: ${JENKINS_SERVICE_NAME}-data
+        - name: ${JENKINS_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${JENKINS_SERVICE_NAME}
     triggers:
     - imageChangeParams:
         automatic: true
@@ -191,19 +207,37 @@ parameters:
   displayName: Enable OAuth in Jenkins
   name: ENABLE_OAUTH
   value: "true"
-- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
-  displayName: Jenkins JVM Architecture
-  name: JVM_ARCH
-  value: i386
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 512Mi
+  value: 1Gi
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
   value: openshift
+- description: Whether to perform memory intensive, possibly slow, synchronization
+    with the Jenkins Update Center on start.  If true, the Jenkins core update monitor
+    and site warnings monitor are disabled.
+  displayName: Disable memory intensive administrative monitors
+  name: DISABLE_ADMINISTRATIVE_MONITORS
+  value: "false"
 - description: Name of the ImageStreamTag to be used for the Jenkins image.
   displayName: Jenkins ImageStreamTag
   name: JENKINS_IMAGE_STREAM_TAG
-  value: jenkins:latest
+  value: jenkins:2
+- description: When a fatal error occurs, an error log is created with information
+    and the state obtained at the time of the fatal error.
+  displayName: Fatal Error Log File
+  name: ENABLE_FATAL_ERROR_LOG_FILE
+  value: "false"
+- description: Whether to allow use of a Jenkins Update Center that uses invalid certificate
+    (self-signed, unknown CA). If any value other than 'false', certificate check
+    is bypassed. By default, certificate check is enforced.
+  displayName: Allows use of Jenkins Update Center repository with invalid SSL certificate
+  name: JENKINS_UC_INSECURE
+  value: "false"


### PR DESCRIPTION
```
commit 2935555c05843d3ff72302425016fe46b375cec5
Date:   Thu Jul 9 13:41:18 2020 -0400

    HACKING.md: update for OCP4

    A bunch of things changed in the OCP UX from OCP3. Notably the CLI for
    creating secrets.

    Also fix missing `JENKINS_JOBS_URL` override needed when defining the
    Jenkins S2I.

commit 403903a501386367b7a47876ecc6eee3d2097d70
Date:   Thu Jul 9 13:42:18 2020 -0400

    manifests: update to latest jenkins-persistent template

    Rebase our Jenkins template on top of the latest OCP4 one, and move from
    jenkins-ephemeral to jenkins-persistent. In the end, it's simply not
    sustainable to retrigger tests for all open PRs in all the repos every
    time our pod is restarted or there's a new rollout.
```