### PR TITLE
jobs/seed-github-ci: nuke workspace for each job

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -34,6 +34,9 @@ node { repos.each { repo ->
                     repository('${name}')
                     checkoutCredentialsId("github-coreosbot-token")
                     scanCredentialsId("github-coreosbot-token")
+                    traits {
+                         wipeWorkspaceTrait()
+                    }
                 }
             }
             factory {


### PR DESCRIPTION
We're hitting an issue in rpm-ostree where Jenkins' `git merge` is
failing because of unmerged files:

https://github.com/coreos/rpm-ostree/pull/2206

Reading https://issues.jenkins-ci.org/browse/JENKINS-44598, this may be
due to re-using the same workspace and accumulating state there,
combined with possibly bugs in the git plugin itself. (Note this is
different from the workspace in which builds happen; this one lives on
the master and is just used for fetching).

Let's just always nuke the workspace.