### PR TITLE
jobs/seed-github-ci: stop wiping workspace

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -77,9 +77,6 @@ node { repos.each { repo ->
                             // allow testing of PRs from project contributors
                             trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait\$TrustContributors')
                         }
-                        'jenkins.plugins.git.traits.WipeWorkspaceTrait' {
-                          extension(class: 'hudson.plugins.git.extensions.impl.WipeWorkspace')
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Otherwise we blow away the git repo which Jenkins uses to know whether
something changed, and so we end up rebuilding all the PRs and branches
every time a branch index refresh happens (currently scheduled for once
a day).

This essentially reverts #18. The original PR which prompted this is
merged now. Let's keep an eye on the upstream issue.