### PR TITLE
Various improvements to make CoreOS CI less greedy

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -60,7 +60,7 @@ is the same (notably, Jenkins and plugin versions):
 ```
 oc process -l app=coreos-ci \
     --param "JENKINS_JOBS_URL=https://github.com/coreos/coreos-ci" \
-    -f https://raw.githubusercontent.com/jlebon/fedora-coreos-pipeline/ocp4/manifests/jenkins-s2i.yaml | oc create -f -
+    -f https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/master/manifests/jenkins-s2i.yaml | oc create -f -
 ```
 
 If working on your own fork/branch, you can point the

--- a/jenkins/config/kubernetes-cap.yaml
+++ b/jenkins/config/kubernetes-cap.yaml
@@ -1,0 +1,16 @@
+groovy:
+  - script: >
+      import jenkins.model.Jenkins;
+
+      CONTAINER_CAP = 15;
+
+      cloud = Jenkins.instance.clouds.find { it.name == "openshift" };
+      if (cloud == null) {
+        throw new Exception("Failed to find cloud openshift");
+      }
+
+      if (cloud.containerCap != CONTAINER_CAP) {
+        cloud.containerCap = CONTAINER_CAP;
+        Jenkins.instance.save();
+        println("Set openshift cloud container cap to $CONTAINER_CAP");
+      }

--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -80,6 +80,11 @@ node { repos.each { repo ->
                         }
                     }
                 }
+                it / sources / data / 'jenkins.branch.BranchSource' / buildStrategies {
+                    'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {
+                        ignoreTargetOnlyChanges(true)
+                    }
+                }
             }
         }
     """


### PR DESCRIPTION
```
commit e15325f8d609399cbfa98301a4828433fef868c7
Date:   Tue Dec 15 20:21:38 2020 -0500

    HACKING.md: fix path to jenkins-s2i.yaml build

commit 295bdffb2ac54c3ec949155bb7410f62f6f24154
Date:   Tue Dec 15 17:37:48 2020 -0500

    jenkins/config: cap max number of pods to 15

    This ensures that we never tax the cluster too hard, which seems to have
    repercussions on other projects like the Fedora CoreOS pipeline.

    Went with 15 for now, we can see how it goes and adapt it up or down in
    the future.

commit 69a720fd0b52ffc95a25e09746c48aa68f0ea716
Date:   Wed Dec 16 10:50:28 2020 -0500

    github-ci: don't rebuild all PRs when base branch changes

    Otherwise, we'll be spamming the cluster too much each time a PR merges.
    This obviously exposes us to "semantic conflicts" (see
    https://bors.tech/essay/2017/02/02/pitch/) again. Fixing this properly
    would require tighter integration in Prow (for projects which use Prow)
    or at least triggering on the same comments.
```