### PR TITLE
jenkins/config: turn on timestamper for all pipeline jobs

### DIFF
--- a/jenkins/config/github-webhook.yaml
+++ b/jenkins/config/github-webhook.yaml
@@ -9,8 +9,8 @@ credentials:
             description: GitHub Webhook Shared Secret
 unclassified:
   gitHubPluginConfig:
-    hookSecretConfig:
-      credentialsId: github-webhook-shared-secret
+    hookSecretConfigs:
+      - credentialsId: github-webhook-shared-secret
     configs:
       - credentialsId: github-coreosbot-token-string
         manageHooks: true

--- a/jenkins/config/timestamper.yaml
+++ b/jenkins/config/timestamper.yaml
@@ -1,0 +1,3 @@
+unclassified:
+  timestamper:
+    allPipelines: true


### PR DESCRIPTION
Follow-up to coreos/fedora-coreos-pipeline#309.

