### PR TITLE
Don't periodically scan branches and cap concurrent pods to 6

### DIFF
--- a/jenkins/config/kubernetes-cap.yaml
+++ b/jenkins/config/kubernetes-cap.yaml
@@ -2,7 +2,7 @@ groovy:
   - script: >
       import jenkins.model.Jenkins;
 
-      CONTAINER_CAP = 15;
+      CONTAINER_CAP = 6;
 
       cloud = Jenkins.instance.clouds.find { it.name == "openshift" };
       if (cloud == null) {

--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -46,11 +46,13 @@ node { repos.each { repo ->
             orphanedItemStrategy {
                 discardOldItems()
             }
-            triggers {
-                // manually rescan once a day; this is important so that it
-                // picks up on deleted branches/PRs which can be cleaned up
-                periodic(60 * 24)
-            }
+            // XXX: disabled for now until we get NFS back because it causes old
+            // PRs to get retested everytime Jenkins is torn down
+            //triggers {
+            //    // manually rescan once a day; this is important so that it
+            //    // picks up on deleted branches/PRs which can be cleaned up
+            //    periodic(60 * 24)
+            //}
             // things which don't seem to have a nice DSL :(
             configure {
                 it / sources / data / 'jenkins.branch.BranchSource' / strategy {


### PR DESCRIPTION
```
commit 7adecf5108c5a2803f0b824c5fe1ff7e733f6102
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Apr 8 09:57:10 2021 -0400

    jobs/seed-github-ci: don't periodically scan branches

    Because we don't have persistent storage, everytime Jenkins gets
    reprovisioned, it wants to test ancient PRs when it does its first
    scheduled repo scan. This unnecessarily bogs down the cluster and
    increases the flakiness of test runs we actually care about.

    So tell Jenkins to stop doing that.

    The downside here is that Jenkins doesn't get to GC deleted
    PRs/branches, but meh... the whole pod gets periodically wiped anyway.
```

```
commit ac366c06a7e85fa51431a8c1069d30c54001ee85
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Apr 8 10:06:44 2021 -0400

    jenkins/config: cap concurrent pods to 6

    Our CI test jobs are demanding and noisy neighbours. If repos are
    particularly active, 15 parallel pods increases the flake rate for
    everyone.

    Let's bring it down to 6 and see how it goes.
```