### PR TITLE
jenkins: increase HEARTBEAT_CHECK_INTERVAL to 10 mins and turn on LAUNCH_DIAGNOSTICS

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -91,6 +91,12 @@ objects:
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
+          # DELTA: Increase heartbeat interval so durable-task-plugin waits a
+          # bit longer for scripts to start before failing the build.
+          # https://github.com/coreos/coreos-ci/issues/28
+          - name: JENKINS_JAVA_OVERRIDES
+            value: >-
+              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -97,6 +97,7 @@ objects:
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600
+              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
```
commit f09d9d8710152044738d3db2aecb44ac28331caa
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Apr 8 12:04:31 2021 -0400

    jenkins: increase HEARTBEAT_CHECK_INTERVAL to 10 mins

    The durable-task-plugin sometimes errors with "process apparently never
    started" if the cluster is under heavy load because the script hasn't
    had a chance to start yet. The default timeout is 5 mins, but let's try
    to bump that to 10 mins to see if it helps. It may be that the problem
    is elsewhere, in which case we can revert this.

    Closes: #28 (hopefully)
```
```
commit d368b0da122955d18c21de9109ba1ade62914f5f
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Apr 8 12:08:24 2021 -0400

    jenkins: turn on LAUNCH_DIAGNOSTICS for durable-task-plugin

    Let's follow what the helper message says and turn this on so that we
    get more logging about what goes wrong when it errors out with "process
    apparently never started".
```