### PR TITLE
Move to local PVC

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,15 @@ oc new-app --file=manifests/jenkins.yaml
 Use the `NAMESPACE` parameter if you're not targeting one
 named `coreos-ci`.
 
+If on the production instance, also create the custom local
+class PVC:
+
+```
+oc create -f manifests/pvc.yaml
+```
+
+Otherwise, you can create a vanilla PVC of the same name.
+
 Create the JCasC configmap:
 
 ```

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -40,16 +40,17 @@ objects:
     to:
       kind: Service
       name: ${JENKINS_SERVICE_NAME}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: ${JENKINS_SERVICE_NAME}
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${VOLUME_CAPACITY}
+# DELTA: we use our own custom PVC
+#- apiVersion: v1
+#  kind: PersistentVolumeClaim
+#  metadata:
+#    name: ${JENKINS_SERVICE_NAME}
+#  spec:
+#    accessModes:
+#    - ReadWriteOnce
+#    resources:
+#      requests:
+#        storage: ${VOLUME_CAPACITY}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -147,7 +148,8 @@ objects:
         volumes:
         - name: ${JENKINS_SERVICE_NAME}-data
           persistentVolumeClaim:
-            claimName: ${JENKINS_SERVICE_NAME}
+            # DELTA: changed from ${JENKINS_SERVICE_NAME} because we use a custom PVC
+            claimName: jenkins-local
         # DELTA: add a configmap -- see config/jcasc.yaml
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:

--- a/manifests/pvc.yaml
+++ b/manifests/pvc.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jenkins-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 223Gi
+  volumeName: local-pv-5ebe93a
+  storageClassName: local-sc
+  volumeMode: Filesystem


### PR DESCRIPTION
After discussions with the CentOS CI folks, I was pointed to an
alternative to the NFS PVC. We can use a "local PVC" which is tied to a
specific node.

This does mean that Jenkins itself will be pinned to that node (but
anyway, all the heavy work is done in separate unconstrained pods) and
that we'll lose all the data if a hardware failure happens (there's no
redundancy/backups like NFS).

This is fine for upstream CI though and is much better than what we
currently have.