### PR TITLE
jenkins/config: workaround jcasc bug in openshift/jenkins

### DIFF
--- a/jenkins/config/kubernetes-plugin.yaml
+++ b/jenkins/config/kubernetes-plugin.yaml
@@ -1,0 +1,10 @@
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1956652
+# should be able to drop this in a future release
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - fileSystemServiceAccountCredential:
+              scope: GLOBAL
+              id: "1a12dfa4-7fc5-47a7-aa17-cc56572a41c7"
+              description: "ServiceAccountToken"


### PR DESCRIPTION
There is a bug in the Jenkins OpenShift image which causes the
Kubernetes credential that it was supposed to create not to happen if
there are JCASC dropins which also create credentials, like we do here.
The symptom is:

    org.jenkinsci.plugins.kubernetes.auth.KubernetesAuthException: No
    credentials found with id 1a12dfa4-7fc5-47a7-aa17-cc56572a41c7

Use the documented workaround to fix this.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1956652
See: https://access.redhat.com/solutions/6016001