### PR TITLE
Revert "jobs/seed-github-ci: don't periodically scan branches"

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -46,13 +46,11 @@ node { repos.each { repo ->
             orphanedItemStrategy {
                 discardOldItems()
             }
-            // XXX: disabled for now until we get NFS back because it causes old
-            // PRs to get retested everytime Jenkins is torn down
-            //triggers {
-            //    // manually rescan once a day; this is important so that it
-            //    // picks up on deleted branches/PRs which can be cleaned up
-            //    periodic(60 * 24)
-            //}
+            triggers {
+                // manually rescan once a day; this is important so that it
+                // picks up on deleted branches/PRs which can be cleaned up
+                periodic(60 * 24)
+            }
             // things which don't seem to have a nice DSL :(
             configure {
                 it / sources / data / 'jenkins.branch.BranchSource' / strategy {


### PR DESCRIPTION
This reverts commit 2c7b5da5e82d8fa69d17dc1d0ed5ce6dbdb244d6.

We have persistent storage now, so let's let Jenkins do its thing so
that it can GC merged/closed/deleted branches and PRs.