### PR TITLE
seed: fix call to get_annotation

### DIFF
--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -17,8 +17,8 @@ jobs:
                 sh("curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/main/utils.groovy")
                 def utils = load("utils.groovy")
 
-                def url = utils.get_annotation("jenkins", "jenkins-jobs-url")
-                def ref = utils.get_annotation("jenkins", "jenkins-jobs-ref")
+                def url = utils.get_annotation("jenkins-jobs-url")
+                def ref = utils.get_annotation("jenkins-jobs-ref")
                 utils.shwrap("rm -rf source")
                 utils.shwrap("git clone -b ^${ref} ^${url} source")
 


### PR DESCRIPTION
The call interface changed to just take one argument.

See https://github.com/coreos/fedora-coreos-pipeline/commit/13b9d25700dfc29f30f02ab4d614eaad99c6b0e0