### PR TITLE
jobs/seed-github-ci: drop coreos/fedora-coreos-streams

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -13,7 +13,6 @@ repos = [
     "coreos/fedora-coreos-cincinnati",
     "coreos/fedora-coreos-config",
     "coreos/fedora-coreos-pipeline",
-    "coreos/fedora-coreos-streams",
     "coreos/ignition",
     "coreos/ignition-dracut",
     "coreos/rpm-ostree",


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-streams/pull/394 moves the tests in that repo to GitHub Actions.