### PR TITLE
manifests/jenkins: bump session timeout

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -99,6 +99,12 @@ objects:
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
+          # DELTA: Increase session timeout to 24h (for docs on each field, see:
+          # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
+          - name: JENKINS_OPTS
+            value: >-
+              --sessionEviction=86400
+              --sessionTimeout=1440
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
The default is 30 minutes, which is short enough that you sometimes have
to log back in multiple times a day. Let's just bump it to one day.

Same as https://github.com/coreos/fedora-coreos-pipeline/pull/456.