### PR TITLE
jobs: don't create jobs in folders

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -3,12 +3,12 @@
 repos = [
     "coreos/afterburn",
     "coreos/bootupd",
+    "coreos/butane",
     "coreos/console-login-helper-messages",
     "coreos/coreos-assembler",
     "coreos/coreos-installer",
     "coreos/coreos-ci",
     "coreos/coreos-ci-lib",
-    "coreos/fcct",
     "coreos/fedora-coreos-releng-automation",
     "coreos/fedora-coreos-cincinnati",
     "coreos/fedora-coreos-config",

--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -23,9 +23,7 @@ repos = [
 node { repos.each { repo ->
     def (owner, name) = repo.split('/')
     jobDsl scriptText: """
-        folder('github-ci')
-        folder('github-ci/${owner}')
-        multibranchPipelineJob('github-ci/${repo}') {
+        multibranchPipelineJob('${name}') {
             branchSources {
                 github {
                     // id must be constant so that job updates work correctly

--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -14,7 +14,6 @@ repos = [
     "coreos/fedora-coreos-config",
     "coreos/fedora-coreos-pipeline",
     "coreos/ignition",
-    "coreos/ignition-dracut",
     "coreos/rpm-ostree",
     "coreos/ssh-key-dir",
     "coreos/zincati",


### PR DESCRIPTION
There's a bug in BlueOcean where a link to a job containing slashes will
not work:

https://issues.jenkins.io/browse/JENKINS-47604

Let's hack around this by not creating folders and just having the jobs
live at the top-level.