### PR TITLE
jobs: drop butane

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -3,7 +3,6 @@
 repos = [
     "coreos/afterburn",
     "coreos/bootupd",
-    "coreos/butane",
     "coreos/console-login-helper-messages",
     "coreos/coreos-assembler",
     "coreos/coreos-installer",


### PR DESCRIPTION
That repo doesn't use CoreOS CI at all, so just delete it.