### PR TITLE
README-upstream-ci.md: fix links to coreos-ci-lib

### DIFF
--- a/README-upstream-ci.md
+++ b/README-upstream-ci.md
@@ -52,9 +52,9 @@ cosaPod {
 ```
 
 The relevant functions used here are
-[cosaPod](https://github.com/coreos/coreos-ci-lib/blob/coreos-ci/vars/cosaPod.groovy)
+[cosaPod](https://github.com/coreos/coreos-ci-lib/blob/main/vars/cosaPod.groovy)
 and
-[fcosBuild](https://github.com/coreos/coreos-ci-lib/blob/coreos-ci/vars/fcosBuild.groovy).
+[fcosBuild](https://github.com/coreos/coreos-ci-lib/blob/main/vars/fcosBuild.groovy).
 
 In practice, it's likely that the `make: true` functionality
 in `coreos-ci-lib` will be too simplistic. The `fcosBuild`


### PR DESCRIPTION
The `coreos-ci` branch is outdated (and will soon be deleted). Fix the
links to use `main`.

Reported-by: Luca BRUNO <luca.bruno@coreos.com>