### PR TITLE
manifests/jenkins: enable OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -96,6 +96,10 @@ objects:
             value: >-
               --sessionEviction=86400
               --sessionTimeout=1440
+          # DELTA: When using a PVC this ensures that plugins are
+          # actually updated when the image gets updated.
+          - name: OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS
+            value: "true"
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
Jenkins stores configs and plugins in a single directory, which is on a
PVC mount. When updating the Jenkins image, by default new plugins in
the image are not copied over into the PVC. If we want to make the image
plugins authoritative (i.e. if we actually want plugin updates), we need
to opt into it via an env var.