### PR TITLE
README-upstream-ci: document contributor trust

### DIFF
--- a/README-upstream-ci.md
+++ b/README-upstream-ci.md
@@ -60,3 +60,25 @@ In practice, it's likely that the `make: true` functionality
 in `coreos-ci-lib` will be too simplistic. The `fcosBuild`
 step can also take an arbitrary `overlays` parameter to pass
 any rootfs directory to overlay.
+
+### Contributor trust
+
+By default, CoreOS CI will refuse to test changes to
+`.cci.jenkinsfile` from contributors that aren't
+collaborators on the target repo. Instead, the
+`.cci.jenkinsfile` will be taken from the target branch for
+testing purposes.
+
+If you'd like to have their changes to `.cci.jenkinsfile`
+tested in the CI for the same PR, then they need to be made
+collaborators. Read access is sufficient.
+
+If this is done through org and team membership (e.g. adding
+them to a team which has read access to the repo), then they
+should ensure that their org membership is public.
+
+Another approach is to have a collaborator resubmit the
+patches in a separate PR on their behalf (original commit
+authorship can and should be kept). This may be more
+appropriate if PRs from the contributor are not expected to
+be frequent, or will not affect multiple repos.


### PR DESCRIPTION
We hit this recently. Let's write this stuff down so it's easier to know
in the future what needs to be done.