### PR TITLE
manifests/jenkins: override default jenkins-agent image

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -86,10 +86,13 @@ objects:
           # DELTA: Increase heartbeat interval so durable-task-plugin waits a
           # bit longer for scripts to start before failing the build.
           # https://github.com/coreos/coreos-ci/issues/28
+          # DELTA: Set the default JNLP image to our Jenkins agent imagestream.
+          # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/change-the-default-jnlp-image-for-kubernetes-agents-provisioning#_system_property_approach
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/jenkins-agent:latest
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS


### PR DESCRIPTION
This matches what we did in the FCOS pipeline:
https://github.com/coreos/fedora-coreos-pipeline/pull/671

The bits from that PR to actually set up the imagestream, we will already inherit here.