### PR TITLE
jobs: add `bodhi-trigger` job

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -1,0 +1,220 @@
+// Useful references:
+// - https://pagure.io/fedora-qa/fedora_openqa/blob/main/f/src/fedora_openqa/consumer.py
+// - https://pagure.io/fedora-ci/general/issue/436
+// - https://github.com/json-path/JsonPath
+// - https://sumiya.page/jpath.html
+
+// XXX: we should move this list to a separate YAML file for knob extensibility
+// in the future (for e.g. which tests to run for each)
+// XXX: one idea is to trigger for all packages in FCOS and only run `basic` by
+// default, and only run more tests for a given subset like the below
+def srpms = [
+    'container-selinux',
+    'glibc',
+    'grub2',
+    'ignition',
+    'kernel',
+    'kexec-tools',
+    'NetworkManager',
+    'ostree',
+    'podman',
+    'rpm-ostree',
+    'rust-afterburn',
+    'rust-coreos-installer',
+    'rust-zincati',
+    'selinux-policy',
+    'systemd'
+]
+
+node {
+    // XXX: we should drain what we need of pipeutils into coreos-ci-lib
+    shwrap("rm -rf pipe && git clone https://github.com/coreos/fedora-coreos-pipeline --depth=1 pipe")
+    // these are script global vars
+    pipeutils = load("pipe/utils.groovy")
+    // XXX: should use load_pipecfg but it checks for arch availability
+    pipecfg = readYaml(file: "pipe/config.yaml")
+
+    // query the currently active streams and collect their releasevers; we'll
+    // use these to update our triggers
+    streams = pipeutils.streams_of_type(pipecfg, 'development') +
+              pipeutils.streams_of_type(pipecfg, 'mechanical')
+    stream_to_releasever = [:]
+    for (st in streams) {
+        // not particularly proud of this, but... it'll work for now
+        shwrap("curl -sSLO https://raw.githubusercontent.com/coreos/fedora-coreos-config/${st}/manifest.yaml")
+        def yaml = readYaml(file: "manifest.yaml")
+        stream_to_releasever[st] = yaml.releasever
+    }
+
+    releasevers = stream_to_releasever.values() as Set
+
+    // query which ones use updates-testing; for more context, see
+    // https://github.com/coreos/coreos-ci/pull/49#issuecomment-1769679589
+    bodhi_composed_releasevers = [] as Set
+    pungi_composed_releasevers = [] as Set
+    for (releasever in releasevers) {
+        def url = "https://bodhi.fedoraproject.org/releases/?name=F${releasever}"
+        if (shwrapRc("curl -sSL ${url} | jq -e '.releases[0].composed_by_bodhi'") == 0) {
+            bodhi_composed_releasevers += releasever
+        } else {
+            pungi_composed_releasevers += releasever
+        }
+    }
+}
+
+properties([
+  pipelineTriggers([
+    ciBuildTrigger(
+      noSquash: true,
+      // The list of triggers below is messy; a core principle here is that
+      // we're trying to push as much filtering as possible into the `checks`
+      // so that a job is only actually run when we need to test something.
+      // This is why we have those gnarly `update.builds[].nvr` checks below.
+      // We should be able to simplify this list a lot once we have
+      // https://pagure.io/fedora-ci/general/issue/436.
+      providerList: [
+        // TL;DR: Effectively triggered when a rawhide/branched update was opened.
+        // Longer explanation: Triggered when an update was pushed to updates-
+        // testing. Since for rawhide (and at the start, branched) updates-
+        // testing doesn't exist, it's immediately triggered on update creation.
+        // We don't care about the non-rawhide case since we don't want to test
+        // when the update is pushed to updates-testing but right away when it's
+        // created (covered by the next trigger below).
+        rabbitMQSubscriber(
+            name: 'Fedora Messaging',
+            overrides: [
+                topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
+                // https://github.com/jenkinsci/jms-messaging-plugin/issues/262
+                queue: 'eb65f4a0-9daa-4689-9bdb-910158b3abba'
+            ],
+            checks: [
+                [field: '$.update.release.id_prefix', expectedValue: '^FEDORA$'],
+                // Is this for a release we care about?
+                [field: '$.update.release.name', expectedValue: "^F(${pungi_composed_releasevers.join("|")})\$"],
+                // Is this for an SRPM we care about? The jsonpath expression
+                // here evaluates to "all builds of type rpm whose nvr matches
+                // 'n-v-r' where 'n' is one of those in $srpms".
+                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$'],
+                // We handle the retrigger case separately below.
+                [field: '$.re-trigger', expectedValue: '^false$']
+            ]
+        ),
+        // TL;DR: Effectively triggered when a non-rawhide update was opened.
+        // Longer explanation: Triggered when an update was requested to be
+        // pushed to updates-testing. This never happens for rawhide, and for
+        // non-rawhide usually happens shortly after the update is opened.
+        rabbitMQSubscriber(
+            name: 'Fedora Messaging',
+            overrides: [
+                topic: 'org.fedoraproject.prod.bodhi.update.request.testing',
+                queue: '6455c3a4-9194-4cc0-a7f6-79864036ded2'
+            ],
+            checks: [
+                [field: '$.update.release.id_prefix', expectedValue: '^FEDORA$'],
+                [field: '$.update.release.name', expectedValue: "^F(${bodhi_composed_releasevers.join("|")})\$"],
+                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$']
+            ]
+        ),
+        // Triggered when an update's tests are requested to be rerun.
+        rabbitMQSubscriber(
+            name: 'Fedora Messaging',
+            overrides: [
+                topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
+                queue: '036407bc-20ad-4290-bdee-deeab6ff6d7a'
+            ],
+            checks: [
+                [field: '$.update.release.id_prefix', expectedValue: '^FEDORA$'],
+                [field: '$.update.release.name', expectedValue: "^F(${releasevers.join("|")})\$"],
+                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$'],
+                // Were we asked to re-run the tests?
+                [field: '$.re-trigger', expectedValue: '^true$']
+            ]
+        ),
+        // Triggered when an update is edited. We only care about the case when
+        // the edit changes the builds in the update (and not e.g. changing
+        // the description).
+        rabbitMQSubscriber(
+            name: 'Fedora Messaging',
+            overrides: [
+                topic: 'org.fedoraproject.prod.bodhi.update.edit',
+                queue: '9a5c5403-0d3f-403c-81b0-e0a6414513b2'
+            ],
+            checks: [
+                [field: '$.update.release.id_prefix', expectedValue: '^FEDORA$'],
+                [field: '$.update.release.name', expectedValue: "^F(${releasevers.join("|")})\$"],
+                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$'],
+                // Were any builds actually changed?
+                [field: 'concat($.new_builds,$.removed_builds)', expectedValue: '^.*$'],
+            ]
+        )
+      ]
+    )
+  ]),
+])
+
+def test_mode = false
+def raw_message = env.CI_MESSAGE
+if (raw_message == null) {
+    raw_message = input(message: 'Triggered manually; running in test mode.', parameters: [text('CI_MESSAGE')])
+    test_mode = true
+}
+
+def msg = readJSON(text: raw_message)
+println("Handling message: ${msg}")
+
+// collect streams with matching releasever
+def releasever = msg.update.release.version.toInteger()
+def matching_streams = []
+for (entry in stream_to_releasever) {
+    if (entry.value == releasever) {
+        matching_streams += [entry.key]
+    }
+}
+
+// This should be covered by the checks embedded in the triggers above, but
+// because of the classic "delayed by one" relationship with the job being
+// triggered updating its own triggers, manually check for this here too.
+if (matching_streams.isEmpty()) {
+    println("Update is for f${releasever} which we don't track anymore.")
+    return
+}
+
+def stream = ""
+if (matching_streams.size() == 1) {
+    stream = matching_streams[0]
+} else if ("testing-devel" in matching_streams) {
+    // It's possible multiple streams track the same version. By far, the most
+    // likely case is testing-devel and next-devel. In the future, we could trigger
+    // for both, but for now just trigger for testing-devel.
+    stream = "testing-devel"
+} else if ("next-devel" in matching_streams) {
+    // Our second-favourite choice in a tie.
+    stream = "next-devel"
+} else {
+    // that shouldn't ever happen, so let's error out for now and if we hit it,
+    // we'll figure out what to do
+    error("multiple non-devel matching streams found: ${matching_streams}")
+}
+
+currentBuild.description = msg.update.builds[0].nvr
+
+if (test_mode) {
+    println("Would trigger test-override with STREAM=${stream}")
+    return
+}
+
+def test = null
+stage("Test") {
+    test = build(job: 'test-override', propagate: false, wait: true,
+                 parameters: [
+                    string(name: 'STREAM', value: stream),
+                    string(name: 'OVERRIDES', value: msg.update.url),
+                 ])
+}
+
+stage("Report") {
+    // XXX: report result to resultsdb
+}
+
+// propagate
+currentBuild.result = test.result

--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -1,0 +1,185 @@
+node {
+    // XXX: we should drain what we need of pipeutils into coreos-ci-lib
+    shwrap("rm -rf pipe && git clone https://github.com/coreos/fedora-coreos-pipeline --depth=1 pipe")
+    // these are script global vars
+    pipeutils = load("pipe/utils.groovy")
+    // XXX: should use load_pipecfg but it checks for arch availability
+    pipecfg = readYaml(file: "pipe/config.yaml")
+}
+
+properties([
+    parameters([
+        string(name: 'OVERRIDES',
+               defaultValue: "",
+               description: 'Space-separated list of Bodhi or Koji URLs'),
+        choice(name: 'STREAM',
+               choices: pipeutils.streams_of_type(pipecfg, 'development') +
+                        pipeutils.streams_of_type(pipecfg, 'mechanical'),
+               description: 'CoreOS development stream to test'),
+        string(name: 'SKIP_TESTS_ARCHES',
+               description: 'Space-separated list of architectures to skip tests on',
+               defaultValue: "",
+               trim: true),
+        string(name: 'COREOS_ASSEMBLER_IMAGE',
+               description: 'Override coreos-assembler image to use',
+               defaultValue: "",
+               trim: true),
+        booleanParam(name: 'ALLOW_KOLA_UPGRADE_FAILURE',
+                     defaultValue: false,
+                     description: "Don't error out if upgrade tests fail (temporary)"),
+    ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '30'
+    )),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+])
+
+// we'll use the first override as our description
+def descPrefix = ""
+
+def bodhi_update_ids = []
+def koji_build_ids = []
+for (url in params.OVERRIDES.split()) {
+    if (url.startsWith("https://bodhi.fedoraproject.org/updates/")) {
+        bodhi_update_ids += url - "https://bodhi.fedoraproject.org/updates/"
+        descPrefix = descPrefix ?: bodhi_update_ids[0]
+    } else if (url.startsWith("https://koji.fedoraproject.org/koji/buildinfo?buildID=")) {
+        koji_build_ids += url -  "https://koji.fedoraproject.org/koji/buildinfo?buildID="
+        descPrefix = descPrefix ?: koji_build_ids[0]
+    } else {
+        error("don't know how to handle override URL $url")
+    }
+}
+
+if (bodhi_update_ids.size() == 0 && koji_build_ids.size() == 0) {
+    error("no overrides provided")
+}
+
+// runtime parameter always wins
+def cosa_img = params.COREOS_ASSEMBLER_IMAGE
+cosa_img = cosa_img ?: pipeutils.get_cosa_img(pipecfg, params.STREAM)
+def stream_info = pipecfg.streams[params.STREAM]
+
+// Keep in sync with build.Jenkinsfile
+def cosa_memory_request_mb = 10.5 * 1024 as Integer
+def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer
+
+currentBuild.description = "[${descPrefix}] Pending"
+
+cosaPod(image: cosa_img,
+        cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
+        serviceAccount: "jenkins") {
+timeout(time: 150, unit: 'MINUTES') {
+try {
+    // resolve to a better title if it's Bodhi
+    if (!bodhi_update_ids.isEmpty()) {
+        descPrefix = shwrapCapture("curl -sSL https://bodhi.fedoraproject.org/updates/${bodhi_update_ids[0]} | jq -r .update.title")
+    }
+    currentBuild.description = "[${descPrefix}] Running"
+
+    def branch = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+    def src_config_commit = shwrapCapture("""
+        git ls-remote ${pipecfg.source_config.url} refs/heads/${branch} | cut -d \$'\t' -f 1
+    """)
+    shwrap("cosa init --branch ${branch} --commit=${src_config_commit} ${pipecfg.source_config.url}")
+
+    // Initialize the sessions on the remote builders
+    def arches = pipeutils.get_additional_arches(pipecfg, params.STREAM) as Set
+    arches = arches.intersect(pipeutils.get_supported_additional_arches()).plus("x86_64")
+    def archinfo = arches.collectEntries{[it, [session: ""]]}
+    stage("Initialize Remotes") {
+        parallel archinfo.keySet().collectEntries{arch -> [arch, {
+            if (arch != "x86_64") {
+                pipeutils.withPodmanRemoteArchBuilder(arch: arch) {
+                    archinfo[arch]['session'] = shwrapCapture("""
+                    cosa remote-session create --image ${cosa_img} --expiration 4h --workdir ${env.WORKSPACE}
+                    """)
+                    withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${archinfo[arch]['session']}"]) {
+                        shwrap("""
+                        cosa init --branch ${branch} --commit=${src_config_commit} ${pipecfg.source_config.url}
+                        """)
+                    }
+                }
+            }
+        }]}
+    }
+
+    // Download overrides
+    stage("Download Overrides") {
+        def parallelruns = [:]
+        for (architecture in archinfo.keySet()) {
+            def arch = architecture
+            parallelruns[arch] = {
+                pipeutils.withOptionalExistingCosaRemoteSession(arch: arch, session: archinfo[arch]['session']) {
+                    for (id in bodhi_update_ids) {
+                        // this would be `bodhi updates download`, but cosa doesn't have it and
+                        // it doesn't seem worth pulling it in just for this
+                        shwrap("""cosa shell -- env -C overrides/rpm sh -c '\
+                                curl -sSL https://bodhi.fedoraproject.org/updates/${id} | \
+                                jq -r .update.builds[].nvr | \
+                                xargs -n 1 koji download-build --arch ${arch} --arch noarch'""")
+                    }
+                    for (id in koji_build_ids) {
+                        // XXX: I think this will fail for a package that doesn't have noarch
+                        // packages nor packages on $arch
+                        shwrap("cosa shell -- env -C overrides/rpm koji download-build ${id} --arch ${arch} --arch noarch")
+                    }
+                }
+            }
+        }
+        parallel parallelruns
+    }
+
+    def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
+    def parallelruns = [:]
+    for (architecture in archinfo.keySet()) {
+        def arch = architecture
+        if (arch in skip_tests_arches) {
+            // The user has explicitly told us that it is OK to
+            // skip tests on this architecture. Presumably because
+            // they already passed in a previous run.
+            continue
+        }
+        parallelruns[arch] = {
+            pipeutils.withOptionalExistingCosaRemoteSession(arch: arch, session: archinfo[arch]['session']) {
+                stage("${arch}:Fetch") {
+                    shwrap("cosa fetch")
+                }
+                stage("${arch}:Build") {
+                    shwrap("cosa build")
+                }
+                def n = ncpus - 1 // remove 1 for upgrade test
+                kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
+                     marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+                stage("${arch}:Build Metal") {
+                    shwrap("cosa buildextend-metal")
+                    shwrap("cosa buildextend-metal4k")
+                }
+                stage("${arch}:Build Live") {
+                    shwrap("cosa buildextend-live --fast")
+                    // Test metal4k with an uncompressed image and
+                    // metal with a compressed one. Limit to 4G to be
+                    // good neighbours and reduce chances of getting
+                    // OOMkilled.
+                    shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=4G cosa compress --artifact=metal")
+                }
+                stage("${arch}:kola:testiso") {
+                    kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                }
+                // Destroy the remote sessions. We don't need them anymore
+                stage("${arch}:Destroy Remote") {
+                    if (arch != "x86_64") {
+                        shwrap("cosa remote-session destroy")
+                    }
+                }
+            }
+        }
+    }
+    parallel parallelruns
+
+    currentBuild.result = 'SUCCESS'
+} catch (e) {
+    currentBuild.result = 'FAILURE'
+    throw e
+}}} // cosaPod, timeout, and try finish here


### PR DESCRIPTION
This job is a step towards better integrating our CI into the rest of
Fedora QA.

The job triggers on Fedora messages from Bodhi whenever an update is
created or edited. It then resolves the Bodhi update to a relevant FCOS
stream, and trigger the `test-override` job with the right parameters.

The implementation details here are a bit messy. Triggering on "a new
Bodhi update" isn't as simple as I would've liked and mapping back to
streams is a bit hairy, but it works!

There's of course a lot of cleanups we could do here (many are marked
in the code), though I'm hoping we can get this in to gain some early
experience and work on cleanups in parallel with the larger task of
adding reporting and socializing it.

See also: https://github.com/coreos/fedora-coreos-tracker/issues/17