### PR TITLE
jobs/bodhi-trigger: add reporting to ResultsDB

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,6 +76,22 @@ oc annotate secret/github-coreosbot-token-username-password  \
     jenkins.io/credentials-description="GitHub coreosbot token as username/password"
 ```
 
+### Create ResultsDB authentication secret
+
+Create the ResultsDB authentication secret (available in BitWarden).
+
+```
+RDB_USERNAME=username
+RDB_PASSWORD=password
+oc create secret generic resultsdb-auth \
+    --from-literal=username=${RDB_USERNAME} \
+    --from-literal=password=${RDB_PASSWORD}
+oc label secret/resultsdb-auth \
+    jenkins.io/credentials-type=usernamePassword
+oc annotate secret/resultsdb-auth  \
+    jenkins.io/credentials-description="ResultsDB authentication"
+```
+
 ### Create pipeline configmap
 
 Run:

--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -203,17 +203,20 @@ if (test_mode) {
     return
 }
 
-def test = null
-stage("Test") {
-    test = build(job: 'test-override', propagate: false, wait: true,
-                 parameters: [
-                    string(name: 'STREAM', value: stream),
-                    string(name: 'OVERRIDES', value: msg.update.url),
-                 ])
-}
+cosaPod(cpu: "0.1", kvm: false) {
+    def test = null
 
-stage("Report") {
-    // XXX: report result to resultsdb
+    stage("Test") {
+        test = build(job: 'test-override', propagate: false, wait: true,
+                     parameters: [
+                        string(name: 'STREAM', value: stream),
+                        string(name: 'OVERRIDES', value: msg.update.url),
+                     ])
+    }
+
+    stage("Report") {
+        // XXX: report result to resultsdb
+    }
 }
 
 // propagate

--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -178,8 +178,10 @@ try {
     }
     parallel parallelruns
 
+    currentBuild.description = "[${descPrefix}] ✔️"
     currentBuild.result = 'SUCCESS'
 } catch (e) {
+    currentBuild.description = "[${descPrefix}] ❌"
     currentBuild.result = 'FAILURE'
     throw e
 }}} // cosaPod, timeout, and try finish here


### PR DESCRIPTION
Call out to the new `resultsdb-report` script in cosa to report test
results back to ResultsDB. Report when first running and then again with
final test results.

Just this alone seems sufficient for the results to show up in Bodhi's
"Automated Tests" tab.

With this, we'll then be able to work on adding policies in Greenwave.

