### PR TITLE
jenkins/config: add JCASC dropin for jms-messaging-plugin

### DIFF
--- a/jenkins/config/jms.yaml
+++ b/jenkins/config/jms.yaml
@@ -1,0 +1,16 @@
+unclassified:
+  jmsProviders:
+    configs:
+      - rabbitMq:
+          name: "Fedora Messaging"
+          hostname: "rabbitmq.fedoraproject.org"
+          portNumber: 5671
+          virtualHost: "/public_pubsub"
+          exchange: "amq.topic"
+          authenticationMethod:
+            sslCertificate:
+              username: "fedora"
+              keystore: "${JENKINS_HOME}/jms-messaging-stores/keystore.jks"
+              keypwd: "fedora"
+              truststore: "${JENKINS_HOME}/jms-messaging-stores/truststore.jks"
+              trustpwd: "fedora"


### PR DESCRIPTION
This configures the JMS messaging plugin to connect to the public endpoint of the Fedora messaging bus.

The tricky thing is passing in the keystores. The plugin does not support using Jenkins credentials[[1]] so we can't leverage kubernetes-credentials-provider.

We could do it the old way, which is to mount the secret into the Jenkins pod, but since d6d1f61, CoreOS CI now uses the exact same `jenkins.yaml` manifest as the production pipeline and we don't want to bind mount it there.

Instead, we hack around this by just baking the keystores in the Jenkins image at `$JENKINS_HOME/jms-messaging-stores`.

[1]: https://github.com/jenkinsci/jms-messaging-plugin/issues/263