### PR TITLE
jobs/bodhi-trigger: fix result propagation

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -250,7 +250,7 @@ cosaPod(cpu: "0.1", kvm: false) {
             """)
         }
     }
-}
 
-// propagate
-currentBuild.result = test.result
+    // propagate
+    currentBuild.result = test.result
+}


### PR DESCRIPTION
When propagating the result of test-override back to bodhi-trigger, we were trying to read from the `test` variable where it was out of scope.

Move it within its scope.