### PR TITLE
jobs/bodhi-trigger: send failure notifications to Matrix

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -94,6 +94,8 @@ oc annotate secret/resultsdb-auth  \
 
 ### Create Fedora Matrix notifications secret
 
+Create the maubot authentication secret (available in BitWarden under `CoreOS CI Fedora Matrix Auth`).
+
 ```
 MATRIX_BOT_TOKEN=auth_token
 MATRIX_BOT_WEBHOOK_URL=url

--- a/HACKING.md
+++ b/HACKING.md
@@ -92,6 +92,20 @@ oc annotate secret/resultsdb-auth  \
     jenkins.io/credentials-description="ResultsDB authentication"
 ```
 
+### Create Fedora Matrix notifications secret
+
+```
+MATRIX_BOT_TOKEN=auth_token
+MATRIX_BOT_WEBHOOK_URL=url
+oc create secret generic matrix-bot-webhook-token \
+    --from-literal=username=${MATRIX_BOT_WEBHOOK} \
+    --from-literal=password=${MATRIX_BOT_TOKEN}
+oc label secret/matrix-bot-webhook-token \
+    jenkins.io/credentials-type=usernamePassword
+oc annotate secret/matrix-bot-webhook-token \
+    jenkins.io/credentials-description="Token for fedora matrix bot webhook"
+```
+
 ### Create pipeline configmap
 
 Run:

--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -250,7 +250,7 @@ cosaPod(cpu: "0.1", kvm: false) {
             """)
         }
         if (test.result != 'SUCCESS') {
-            matrixSendMessage(hostname: 'fedora.im', accessTokenCredentialsId: 'CREDS', roomId: 'ROOM', body: "${currentBuild.description} - ${outcome}")
+            pipeutils.matrixSend("${currentBuild.description} - ${outcome}")
         }
     }
 

--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -250,7 +250,7 @@ cosaPod(cpu: "0.1", kvm: false) {
             """)
         }
         if (test.result != 'SUCCESS') {
-            pipeutils.matrixSend("${currentBuild.description} - ${outcome}")
+            pipeutils.matrixSend(":fire: [:ocean:](${blueocean_url}) ${currentBuild.description} - ${outcome} ")
         }
     }
 

--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -249,6 +249,9 @@ cosaPod(cpu: "0.1", kvm: false) {
                 --stream ${stream}
             """)
         }
+        if (test.result != 'SUCCESS') {
+            matrixSendMessage(hostname: 'fedora.im', accessTokenCredentialsId: 'CREDS', roomId: 'ROOM', body: "${currentBuild.description} - ${outcome}")
+        }
     }
 
     // propagate


### PR DESCRIPTION
This job is still relatively new. Push out failure notifications to Matrix to increase visibility and make it easier to collaborate on investigating issues.