### PR TITLE
jobs/bodhi-trigger: fix CI retrigger message handling

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -72,9 +72,7 @@ properties([
                 // Is this for an SRPM we care about? The jsonpath expression
                 // here evaluates to "all builds of type rpm whose nvr matches
                 // 'n-v-r' where 'n' is one of those in $srpms".
-                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$'],
-                // We handle the retrigger case separately below.
-                [field: '$.re-trigger', expectedValue: '^false$']
+                [field: "\$.update.builds[?(@.type == 'rpm' && @.nvr =~ /^(${srpms.join("|")})-[^-]+-[^-]+\$/)]", expectedValue: '^\\[.+\\]$']
             ]
         )
       ]


### PR DESCRIPTION
Missed removing this bit from 4509014 ("jobs/bodhi-trigger: simplify triggering").