### PR TITLE
bodhi-testing.yaml: make test patterns more globby

### DIFF
--- a/bodhi-testing.yaml
+++ b/bodhi-testing.yaml
@@ -26,12 +26,12 @@ srpms:
     - name: grub2
     - name: kernel
     - name: kexec-tools
-      test-patterns: 'ext.config.kdump.*'
+      test-patterns: '*kdump*'
       testiso-patterns: skip
     - name: NetworkManager
     - name: openssh
     - name: moby-engine
-      test-patterns: 'ext.config.docker.*'
+      test-patterns: '*docker*'
       testiso-patterns: skip
     - name: nmstate
       test-patterns: 'ext.config.networking.*'
@@ -41,6 +41,6 @@ srpms:
     - name: selinux-policy
     - name: systemd
     - name: toolbox
-      test-patterns: 'ext.config.toolbox.*'
+      test-patterns: '*toolbox*'
       testiso-patterns: skip
     - name: util-linux


### PR DESCRIPTION
The test pattern for `toolbox` was incorrect and so didn't match anything.

For that component and some others, instead of specifying a full test path, make the patterns more globby. That makes them more obviously right, and resistant to the tests moving.

Fixes 6c1f869 ("bodhi-testing.yaml: support specifying tests to run").