### PR TITLE
jobs/seed-github-ci: add openshift/os

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -16,6 +16,7 @@ repos = [
     "coreos/rpm-ostree",
     "coreos/ssh-key-dir",
     "coreos/zincati",
+    "openshift/os",
     "ostreedev/ostree"
 ]
 


### PR DESCRIPTION
The Prow CI we have in those repos are extremely slow and annoying to maintain. We're still going to need it for now to at least build RHCOS with actual RHEL RPMs, but at least for CentOS Stream we should be able to build that fine in CoreOS CI. (We don't have access to the OCP RPMs, but with https://github.com/openshift/os/issues/799, we'll move those out of the base compose anyway.)