### PR TITLE
jobs/bodhi-trigger: report SUCCESS even for UNSTABLE builds

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -168,10 +168,11 @@ cosaPod(cpu: "0.1", kvm: false) {
 
     stage("Report Completion") {
         def outcome
-        if (test.result == 'SUCCESS') {
+        // treat UNSTABLE as PASSED too; we often have expired snoozed tests
+        // that'll warn and Greenwave/Bodhi treats NEEDS_INSPECTION outcomes
+        // as blocking
+        if (test.result == 'SUCCESS' || test.result == 'UNSTABLE') {
             outcome = 'PASSED'
-        } else if (test.result == 'UNSTABLE') {
-            outcome = 'NEEDS_INSPECTION'
         } else {
             outcome = 'FAILED'
         }


### PR DESCRIPTION
When a snoozed test expires, if it has the `warn: true` key on, we'll start warning and that'll show up as an UNSTABLE build. These warnings are more for test maintainers than for public consumption so don't translate them to NEEDS_INSPECTION because that will block updates on gated components.