### PR TITLE
jobs/bodhi-trigger: respect `test-patterns: skip`

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -153,7 +153,7 @@ cosaPod(cpu: "0.1", kvm: false) {
         // always force at least `basic` to run; that way even if all of the
         // specified tests are denylisted because they're temporarily broken, we
         // still get a sanity-check that it doesn't break boot
-        if (test_patterns != "") {
+        if (test_patterns != "" && test_patterns != "skip") {
             test_patterns += " basic"
         }
 


### PR DESCRIPTION
If a test pattern is marked as `skip`, then respect that. Don't force `basic` to run in that case. The logic there was meant as a way to force `basic` to always run *if* some other tests were also selected, not to counteract `skip`.

Fixes 6c1f869 ("bodhi-testing.yaml: support specifying tests to run").