### PR TITLE
jobs/test-override: run `cosa fetch` with `--with-cosa-overrides`

### DIFF
--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -192,7 +192,7 @@ try {
                     autolock_arg = "--autolock ${build_lock}"
                 }
                 stage("${arch}:Fetch") {
-                    shwrap("cosa fetch ${autolock_arg}")
+                    shwrap("cosa fetch --with-cosa-overrides ${autolock_arg}")
                 }
                 stage("${arch}:Build") {
                     shwrap("cosa build ${autolock_arg}")


### PR DESCRIPTION
Otherwise, if the override we're testing is pulling in new dependencies, we won't know to fetch them. This came up in https://bodhi.fedoraproject.org/updates/FEDORA-2024-969f546f80 which is adding a dep on `composefs`.

This also matches CI in the coreos/fedora-coreos-config repo.

(Aside: we've talked in the past about getting notified when new deps are added and the previous behaviour coincidentally did that, but this doesn't seem like the right place for it; we shouldn't block packages from entering Fedora on that account. That check probably belongs in `bump-lockfile` instead).