### PR TITLE
jobs/bodhi-trigger: print raw JSON instead of parsed object

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -77,8 +77,8 @@ if (raw_message == null) {
     test_mode = true
 }
 
+println("Handling message: ${raw_message}")
 def msg = readJSON(text: raw_message)
-println("Handling message: ${msg}")
 
 // collect streams with matching releasever
 def releasever = msg.update.release.version.toInteger()


### PR DESCRIPTION
That makes it easier to copy/paste if we want to replay a job (currently even replaying a fedmsg-triggered job will still ask you to input the `CI_MESSAGE`).