### PR TITLE
bodhi-testing: add kexec-tools and makedumpfile

### DIFF
--- a/bodhi-testing.yaml
+++ b/bodhi-testing.yaml
@@ -28,6 +28,12 @@ srpms:
     - name: kexec-tools
       test-patterns: '*kdump*'
       testiso-patterns: skip
+    - name: kdump-utils
+      test-patterns: '*kdump*'
+      testiso-patterns: skip
+    - name: makedumpfile
+      test-patterns: '*kdump*'
+      testiso-patterns: skip
     - name: NetworkManager
     - name: openssh
     - name: moby-engine


### PR DESCRIPTION
We need to also tests theses, as we need them to support kdump. This would have caught https://github.com/coreos/fedora-coreos-tracker/issues/1813