### PR TITLE
upstream-ci: test upstream kdump builds against FCOS

### DIFF
--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -17,7 +17,8 @@ repos = [
     "coreos/ssh-key-dir",
     "coreos/zincati",
     "openshift/os",
-    "ostreedev/ostree"
+    "ostreedev/ostree",
+    "rhkdump/kdump-utils"
 ]
 
 node { repos.each { repo ->


### PR DESCRIPTION
In an effort to reduce kdump issues, let's run our tests against their upstream repo, to catch problems earlier.

See https://github.com/rhkdump/kdump-utils/pull/62 Also: https://issues.redhat.com/browse/RHEL-70438