### PR TITLE
lower resultsdb reporting into test-override job

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -115,7 +115,18 @@ if (matching_streams.size() == 1) {
     error("multiple non-devel matching streams found: ${matching_streams}")
 }
 
-currentBuild.description = msg.update.builds[0].nvr
+// Find the builds in the update we care about and update the
+// description with those build NVRs.
+def coreos_builds = []
+for (srpm in srpms) {
+    for (build in msg.update.builds) {
+        if (build.nvr.startsWith(srpm)) {
+            coreos_builds += build.nvr
+        }
+    }
+}
+currentBuild.description = coreos_builds.join(" ")
+
 
 if (test_mode) {
     println("Would trigger test-override with STREAM=${stream}")
@@ -150,6 +161,7 @@ cosaPod(cpu: "0.1", kvm: false) {
                  string(name: 'OVERRIDES', value: msg.update.url),
                  string(name: 'TESTS', value: test_patterns),
                  string(name: 'TESTISO_TESTS', value: testiso_patterns),
+                 string(name: 'DESCRIPTION', value: currentBuild.description),
                  string(name: 'REPORT_TO_RESULTSDB', value: true),
               ])
     }

--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -51,6 +51,7 @@ properties([
         rabbitMQSubscriber(
             name: 'Fedora Messaging',
             overrides: [
+                // https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete&delta=100000
                 topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
                 // https://github.com/jenkinsci/jms-messaging-plugin/issues/262
                 queue: 'eb65f4a0-9daa-4689-9bdb-910158b3abba'

--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -198,7 +198,7 @@ try {
                 stage("${arch}:Fetch") {
                     shwrap("cosa fetch --with-cosa-overrides ${autolock_arg}")
                 }
-                stage("${arch}:Build") {
+                stage("${arch}:Build OSTree/QEMU") {
                     shwrap("cosa build ${autolock_arg}")
                 }
                 if (params.TESTS != "skip") {
@@ -207,12 +207,8 @@ try {
                          marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
                 }
                 if (params.TESTISO_TESTS != "skip") {
-                    stage("${arch}:Build Metal") {
-                        shwrap("cosa buildextend-metal")
-                        shwrap("cosa buildextend-metal4k")
-                    }
                     stage("${arch}:Build Live") {
-                        shwrap("cosa buildextend-live --fast")
+                        shwrap("cosa osbuild metal metal4k live")
                         // Test metal4k with an uncompressed image and
                         // metal with a compressed one. Limit to 4G to be
                         // good neighbours and reduce chances of getting


### PR DESCRIPTION
This way one can easily replay ↺ a job to retry a failed test and still have the results reported back to Bodhi.

Should resolve https://github.com/coreos/coreos-ci/issues/64