### PR TITLE
jobs/test-override: bump timeout to 200m

### DIFF
--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -95,7 +95,7 @@ cosaPod(image: cosa_img,
         cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
         env: container_env,
         serviceAccount: "jenkins") {
-timeout(time: 150, unit: 'MINUTES') {
+timeout(time: 200, unit: 'MINUTES') {
 try {
     // Set a sane build description if none was provided
     if (descPrefix == "") {


### PR DESCRIPTION
We had a recent job timeout because it went over 150. Absent of us trimming tests, let's bump it for now.