### PR TITLE
jobs/test-override: disable buildah path for now

### DIFF
--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -103,6 +103,9 @@ def stream_info = pipecfg.streams[params.STREAM]
 // Grab any environment variables we should set
 def container_env = pipeutils.get_env_vars_for_stream(pipecfg, params.STREAM)
 
+// XXX: Temporarily disable buildah path while we stabilize it in rawhide.
+container_env.remove('COSA_BUILD_WITH_BUILDAH')
+
 // Keep in sync with build.Jenkinsfile
 def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer


### PR DESCRIPTION
We're still ironing out issues, but we don't want to cause confusion with Bodhi users. So for now just keep using the legacy path.