### PR TITLE
Revert "jobs/test-override: disable buildah path for now"

### DIFF
--- a/jobs/test-override.Jenkinsfile
+++ b/jobs/test-override.Jenkinsfile
@@ -103,9 +103,6 @@ def stream_info = pipecfg.streams[params.STREAM]
 // Grab any environment variables we should set
 def container_env = pipeutils.get_env_vars_for_stream(pipecfg, params.STREAM)
 
-// XXX: Temporarily disable buildah path while we stabilize it in rawhide.
-container_env.remove('COSA_BUILD_WITH_BUILDAH')
-
 // Keep in sync with build.Jenkinsfile
 def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer


### PR DESCRIPTION
Tests are passing in the buildah path for now so let's re-activate it for streams where it is configured.

This reverts commit 7579d142427776ba5a4f8e6313d8c5dc59b99ad1.