### PR TITLE
jobs/bodhi-trigger: update stream_to_releasever logic

### DIFF
--- a/jobs/bodhi-trigger.Jenkinsfile
+++ b/jobs/bodhi-trigger.Jenkinsfile
@@ -31,9 +31,9 @@ node {
     stream_to_releasever = [:]
     for (st in streams) {
         // not particularly proud of this, but... it'll work for now
-        shwrap("curl -sSLO https://raw.githubusercontent.com/coreos/fedora-coreos-config/${st}/manifest.yaml")
-        def yaml = readYaml(file: "manifest.yaml")
-        stream_to_releasever[st] = yaml.releasever
+        shwrap("curl -sSLO https://raw.githubusercontent.com/coreos/fedora-coreos-config/${st}/build-args.conf")
+        def properties = readProperties(file: "build-args.conf")
+        stream_to_releasever[st] = properties.VERSION.toInteger()
     }
 
     releasevers = stream_to_releasever.values() as Set


### PR DESCRIPTION
We moved the definition of the version/releasever in [1] to build-args.conf so we need to update the logic here to source in from that location instead of the manifest.

[1] https://github.com/coreos/fedora-coreos-config/commit/6fc060cd8a42e0e8369b9e84d67b6c400eeb863a